### PR TITLE
Text localization examples

### DIFF
--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery.xcodeproj/project.pbxproj
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		7179CF852B26DEDD00C5927B /* TextAccessibilityPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7179CF842B26DEDD00C5927B /* TextAccessibilityPage.swift */; };
 		7179CF872B26DF0E00C5927B /* TextLocalizationPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7179CF862B26DF0E00C5927B /* TextLocalizationPage.swift */; };
 		719116892B216D500007C4DE /* TextPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 719116882B216D500007C4DE /* TextPage.swift */; };
+		B3CBD1552B2E18320095DE1F /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B3CBD1542B2E18320095DE1F /* Localizable.xcstrings */; };
+		B3CBD1572B2E1BE20095DE1F /* LocalizableAlternative.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = B3CBD1562B2E1BE20095DE1F /* LocalizableAlternative.xcstrings */; };
 		C902DDE52AE38C8A00242DBA /* VStackExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = C902DDE42AE38C8A00242DBA /* VStackExamples.swift */; };
 		C902DDE72AE3904400242DBA /* TodoPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C902DDE62AE3904400242DBA /* TodoPage.swift */; };
 		C9CAE2812AC23AB40042DBC7 /* swift_ui_galleryApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CAE2802AC23AB40042DBC7 /* swift_ui_galleryApp.swift */; };
@@ -50,6 +52,8 @@
 		7179CF842B26DEDD00C5927B /* TextAccessibilityPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAccessibilityPage.swift; sourceTree = "<group>"; };
 		7179CF862B26DF0E00C5927B /* TextLocalizationPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLocalizationPage.swift; sourceTree = "<group>"; };
 		719116882B216D500007C4DE /* TextPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPage.swift; sourceTree = "<group>"; };
+		B3CBD1542B2E18320095DE1F /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		B3CBD1562B2E1BE20095DE1F /* LocalizableAlternative.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = LocalizableAlternative.xcstrings; sourceTree = "<group>"; };
 		C902DDE42AE38C8A00242DBA /* VStackExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VStackExamples.swift; sourceTree = "<group>"; };
 		C902DDE62AE3904400242DBA /* TodoPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoPage.swift; sourceTree = "<group>"; };
 		C9CAE27D2AC23AB40042DBC7 /* swift_ui_gallery.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = swift_ui_gallery.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -153,6 +157,8 @@
 		C9CAE27F2AC23AB40042DBC7 /* swift_ui_gallery */ = {
 			isa = PBXGroup;
 			children = (
+				B3CBD1542B2E18320095DE1F /* Localizable.xcstrings */,
+				B3CBD1562B2E1BE20095DE1F /* LocalizableAlternative.xcstrings */,
 				C9CAE2B92AE108790042DBC7 /* layouts */,
 				C9CAE2B82AE107E10042DBC7 /* motion */,
 				C9CAE2B72AE107DB0042DBC7 /* controls */,
@@ -329,6 +335,7 @@
 			knownRegions = (
 				en,
 				Base,
+				it,
 			);
 			mainGroup = C9CAE2742AC23AB40042DBC7;
 			productRefGroup = C9CAE27E2AC23AB40042DBC7 /* Products */;
@@ -347,8 +354,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B3CBD1572B2E1BE20095DE1F /* LocalizableAlternative.xcstrings in Resources */,
 				C9CAE2882AC23AB50042DBC7 /* Preview Assets.xcassets in Resources */,
 				C9CAE2852AC23AB50042DBC7 /* Assets.xcassets in Resources */,
+				B3CBD1552B2E18320095DE1F /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -545,6 +554,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"swift_ui_gallery/Preview Content\"";
+				DEVELOPMENT_TEAM = N7KJW4K2G9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -573,6 +583,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"swift_ui_gallery/Preview Content\"";
+				DEVELOPMENT_TEAM = N7KJW4K2G9;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery.xcodeproj/xcshareddata/xcschemes/swift_ui_gallery.xcscheme
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery.xcodeproj/xcshareddata/xcschemes/swift_ui_gallery.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9CAE27C2AC23AB40042DBC7"
+               BuildableName = "swift_ui_gallery.app"
+               BlueprintName = "swift_ui_gallery"
+               ReferencedContainer = "container:swift_ui_gallery.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9CAE28C2AC23AB50042DBC7"
+               BuildableName = "swift_ui_galleryTests.xctest"
+               BlueprintName = "swift_ui_galleryTests"
+               ReferencedContainer = "container:swift_ui_gallery.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C9CAE2962AC23AB50042DBC7"
+               BuildableName = "swift_ui_galleryUITests.xctest"
+               BlueprintName = "swift_ui_galleryUITests"
+               ReferencedContainer = "container:swift_ui_gallery.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9CAE27C2AC23AB40042DBC7"
+            BuildableName = "swift_ui_gallery.app"
+            BlueprintName = "swift_ui_gallery"
+            ReferencedContainer = "container:swift_ui_gallery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C9CAE27C2AC23AB40042DBC7"
+            BuildableName = "swift_ui_gallery.app"
+            BlueprintName = "swift_ui_gallery"
+            ReferencedContainer = "container:swift_ui_gallery.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
@@ -1,6 +1,18 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "_NOW visit our [website](https://www.example.com)._" : {
+      "comment" : "no comment",
+      "extractionState" : "stale",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "test??"
+          }
+        }
+      }
+    },
     "_Please visit our [website](https://www.example.com)._" : {
       "localizations" : {
         "it" : {
@@ -13,6 +25,22 @@
     },
     "Accessibility" : {
 
+    },
+    "Add ^[%lld %@ %@](inflect: true) to your order" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Add ^[%1$lld %2$@ %3$@](inflect: true) to your order"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aggiungi ^[%1$lld %2$@ %3$@](inflect: true) al tuo ordine"
+          }
+        }
+      }
     },
     "All styles" : {
 
@@ -139,6 +167,16 @@
     "Image" : {
 
     },
+    "large" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "grande"
+          }
+        }
+      }
+    },
     "Large Title" : {
 
     },
@@ -162,13 +200,22 @@
     "Localization" : {
 
     },
+    "Localize" : {
+
+    },
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam efficitur, enim sit amet sodales rhoncus, nisl nisl varius urna, ut pulvinar odio nibh ac lorem. Etiam sit amet viverra erat, venenatis egestas tellus. Curabitur nec sodales lorem, nec tincidunt velit. Duis sed dolor pretium, viverra magna et, vehicula turpis. Cras suscipit venenatis felis, a dignissim nulla consequat sed. Sed non lacus nec velit vestibulum consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam dignissim, ligula id condimentum feugiat, odio mi dapibus risus, quis pulvinar risus elit non ex.\nDonec vitae nisl ornare, efficitur mi vitae, maximus mauris. Curabitur imperdiet commodo tellus, vel pellentesque purus bibendum a. Nunc molestie ut nulla eu accumsan. Proin placerat metus sagittis, elementum augue vel, posuere dui. Aenean viverra enim in leo gravida, vel mollis leo vehicula. Duis aliquet convallis volutpat. Vivamus a nulla velit. Fusce vestibulum libero in cursus feugiat." : {
+
+    },
+    "Magic" : {
 
     },
     "Middle Aligned" : {
 
     },
     "Motion" : {
+
+    },
+    "Other initializers" : {
 
     },
     "pen" : {
@@ -197,6 +244,16 @@
     },
     "Red" : {
 
+    },
+    "salad" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "insalata"
+          }
+        }
+      }
     },
     "Scaffolds" : {
 
@@ -241,6 +298,9 @@
 
     },
     "Text" : {
+
+    },
+    "Text initialization from string + localization table specification" : {
 
     },
     "Third" : {

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
@@ -146,6 +146,7 @@
 
     },
     "Lightbulbs" : {
+      "extractionState" : "stale",
       "localizations" : {
         "it" : {
           "stringUnit" : {
@@ -159,6 +160,9 @@
 
     },
     "Localization" : {
+
+    },
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam efficitur, enim sit amet sodales rhoncus, nisl nisl varius urna, ut pulvinar odio nibh ac lorem. Etiam sit amet viverra erat, venenatis egestas tellus. Curabitur nec sodales lorem, nec tincidunt velit. Duis sed dolor pretium, viverra magna et, vehicula turpis. Cras suscipit venenatis felis, a dignissim nulla consequat sed. Sed non lacus nec velit vestibulum consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam dignissim, ligula id condimentum feugiat, odio mi dapibus risus, quis pulvinar risus elit non ex.\nDonec vitae nisl ornare, efficitur mi vitae, maximus mauris. Curabitur imperdiet commodo tellus, vel pellentesque purus bibendum a. Nunc molestie ut nulla eu accumsan. Proin placerat metus sagittis, elementum augue vel, posuere dui. Aenean viverra enim in leo gravida, vel mollis leo vehicula. Duis aliquet convallis volutpat. Vivamus a nulla velit. Fusce vestibulum libero in cursus feugiat." : {
 
     },
     "Middle Aligned" : {

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
@@ -1,0 +1,280 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "_Please visit our [website](https://www.example.com)._" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "_Visita il nostro [sito](https://www.example.com)_"
+          }
+        }
+      }
+    },
+    "Accessibility" : {
+
+    },
+    "All styles" : {
+
+    },
+    "another pencil" : {
+      "comment" : "Translator comment",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "un'altra matita"
+          }
+        }
+      }
+    },
+    "Blue" : {
+
+    },
+    "Bottom Aligned" : {
+
+    },
+    "Brevity is the soul of wit." : {
+
+    },
+    "Callout" : {
+
+    },
+    "Collections" : {
+
+    },
+    "Controls" : {
+
+    },
+    "default scale" : {
+
+    },
+    "Emoji: 💙" : {
+
+    },
+    "Exceeds available space" : {
+
+    },
+    "First" : {
+
+    },
+    "fontDesign: default" : {
+
+    },
+    "fontDesign: monospaced" : {
+
+    },
+    "fontDesign: rounded" : {
+
+    },
+    "fontDesign: serif" : {
+
+    },
+    "fontWeight: black" : {
+
+    },
+    "fontWeight: bold" : {
+
+    },
+    "fontWeight: heavy" : {
+
+    },
+    "fontWeight: light" : {
+
+    },
+    "fontWeight: medium" : {
+
+    },
+    "fontWeight: regular" : {
+
+    },
+    "fontWeight: semibold" : {
+
+    },
+    "fontWeight: ultraLight" : {
+
+    },
+    "fontWidth: compressed" : {
+
+    },
+    "fontWidth: condensed" : {
+
+    },
+    "fontWidth: expanded" : {
+
+    },
+    "fontWidth: standard" : {
+
+    },
+    "Footnote" : {
+
+    },
+    "Frame" : {
+
+    },
+    "Green" : {
+
+    },
+    "Grid" : {
+
+    },
+    "Headline" : {
+
+    },
+    "Hello" : {
+
+    },
+    "Hello world" : {
+
+    },
+    "Hello, 12345!" : {
+
+    },
+    "Hello, world!" : {
+
+    },
+    "HStack" : {
+
+    },
+    "Image" : {
+
+    },
+    "Large Title" : {
+
+    },
+    "Layouts" : {
+
+    },
+    "Lightbulbs" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lampadine"
+          }
+        }
+      }
+    },
+    "Lists" : {
+
+    },
+    "Localization" : {
+
+    },
+    "Middle Aligned" : {
+
+    },
+    "Motion" : {
+
+    },
+    "pen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "penna"
+          }
+        }
+      }
+    },
+    "pencil" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "matita"
+          }
+        }
+      }
+    },
+    "Primitives" : {
+
+    },
+    "Red" : {
+
+    },
+    "Scaffolds" : {
+
+    },
+    "Second" : {
+
+    },
+    "secondary scale" : {
+
+    },
+    "Subheadline" : {
+
+    },
+    "System font - 18, black, monospace" : {
+
+    },
+    "System font - 18, black, rounded" : {
+
+    },
+    "System font - 18, black, serif" : {
+
+    },
+    "System font - 18, light, monospace" : {
+
+    },
+    "System font - 18, light, rounded" : {
+
+    },
+    "System font - 18, light, serif" : {
+
+    },
+    "System font - 18, medium, monospace" : {
+
+    },
+    "System font - 18, medium, rounded" : {
+
+    },
+    "System font - 18, medium, serif" : {
+
+    },
+    "Tables" : {
+
+    },
+    "Text" : {
+
+    },
+    "Third" : {
+
+    },
+    "This page still needs to be spec'd and built. Wanna hepl?" : {
+
+    },
+    "Title" : {
+
+    },
+    "Title 2" : {
+
+    },
+    "Title 3" : {
+
+    },
+    "To be, or not to be, that is the question:" : {
+
+    },
+    "Top Aligned" : {
+
+    },
+    "Typography" : {
+
+    },
+    "UI Primitives" : {
+
+    },
+    "UX divisions" : {
+
+    },
+    "VStack" : {
+
+    },
+    "ZStack" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/LocalizableAlternative.xcstrings
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/LocalizableAlternative.xcstrings
@@ -1,0 +1,16 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "pencil" : {
+      "localizations" : {
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "lapis"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
 struct TextLocalizationPage: View {
-    @State private var localize = false
+    @State private var localize: Bool
+
+    init(localize: Bool = false) {
+        _localize = State(initialValue: localize)
+    }
     
     var body: some View {
         Toggle(isOn: $localize, label: {
@@ -33,7 +37,7 @@ struct TextLocalizationPage: View {
                 // This comment will be ignored, since the same key was declared earlier. This is valid even if no comment was specified on the previous key.
                 Text("another pencil", comment: "A different comment")
                 
-                // Specify a different table for this localization, this must be the name of an existing string catalog. If the table is not found, the string will not be localized
+                // Specify a different table for this localization, this must be the name of an existing string catalog. If the table is not found, the string will not be localized.
                 Text("pencil", tableName: "LocalizableAlternative")
                 
                 // Specify a bundle that contains the localizations table (Bundle.main is the default)
@@ -57,9 +61,24 @@ struct TextLocalizationPage: View {
                 let resource = LocalizedStringResource("pencil")
                 Text(resource)
                 
+                // String initializer
+                let string = String(localized: "pencil")
+                Text(LocalizedStringKey(string))
+                
+                // AttributedString initializer
+                // Warning: At present, localized AttributedString can only be displayed in the language currently set in the system and cannot be specified as a specific language. Run with the "swift_ui_gallery it" scheme to see it working
+                let attributed = AttributedString(localized: "pencil")
+                Text(attributed)
+                
                 Divider()
                 
-                // TODO add AttributedString examples
+                Text("Automatic grammar agreement").font(.title2)
+                
+                // for supported languages, adding the `inflect: true` attribute automatically changes the localized strings to agree with amounts and genders.
+                let quantity = 2
+                let size = LocalizedStringResource("large")
+                let food = LocalizedStringResource("salad")
+                Text("Add ^[\(quantity) \(size) \(food)](inflect: true) to your order")
             }
         }.navigationTitle("Localization")
             .environment(\.locale, $localize.wrappedValue ? .init(identifier: "it") : .current)
@@ -71,5 +90,5 @@ struct TextLocalizationPage: View {
 }
 
 #Preview("Italian") {
-    TextLocalizationPage().environment(\.locale, .init(identifier: "it"))
+    TextLocalizationPage(localize: true)
 }

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
@@ -1,14 +1,31 @@
 import SwiftUI
 
 struct TextLocalizationPage: View {
+    @State private var localize = false
     
     var body: some View {
+        Toggle(isOn: $localize, label: {
+            Text("Localize")
+        }).padding()
+        
         ScrollView {
             VStack(spacing: 24) {
+                /* Localizations are stored in "string catalogs" (.xcstrings files) which are bundled with the application at compile time. Once a catalog is created, Xcode can extract all localazible strings at compile time and place them in the catalog.
+                 In the following examples, "localization tables" refer to the string catalogs.
+                 */
+                
+                Text("Text initialization from string + localization table specification").font(.title2)
+                
                 // Text's initializer accepts a LocalizedStringKey, which can be implicitly constructed from a string literal
                 // The value of the string is used for the development language localization
                 // Values for other languages are looked up in the default table using the string as key, if not found the value is used as is
                 Text("pencil")
+                
+                // The whole key is used as the key in the localization table, even if it contains multiple paragraphs
+                Text("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam efficitur, enim sit amet sodales rhoncus, nisl nisl varius urna, ut pulvinar odio nibh ac lorem. Etiam sit amet viverra erat, venenatis egestas tellus. Curabitur nec sodales lorem, nec tincidunt velit. Duis sed dolor pretium, viverra magna et, vehicula turpis. Cras suscipit venenatis felis, a dignissim nulla consequat sed. Sed non lacus nec velit vestibulum consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam dignissim, ligula id condimentum feugiat, odio mi dapibus risus, quis pulvinar risus elit non ex.\nDonec vitae nisl ornare, efficitur mi vitae, maximus mauris. Curabitur imperdiet commodo tellus, vel pellentesque purus bibendum a. Nunc molestie ut nulla eu accumsan. Proin placerat metus sagittis, elementum augue vel, posuere dui. Aenean viverra enim in leo gravida, vel mollis leo vehicula. Duis aliquet convallis volutpat. Vivamus a nulla velit. Fusce vestibulum libero in cursus feugiat.").font(.system(size: 10))
+                
+                // Markdown-formatted strings can also be localized
+                Text("_Please visit our [website](https://www.example.com)._")
                 
                 // The comment is shown in the localization table, useful for giving context to translators
                 Text("another pencil", comment: "Translator comment")
@@ -16,13 +33,15 @@ struct TextLocalizationPage: View {
                 // This comment will be ignored, since the same key was declared earlier. This is valid even if no comment was specified on the previous key.
                 Text("another pencil", comment: "A different comment")
                 
-                // Specify a different table for this localization
+                // Specify a different table for this localization, this must be the name of an existing string catalog. If the table is not found, the string will not be localized
                 Text("pencil", tableName: "LocalizableAlternative")
                 
                 // Specify a bundle that contains the localizations table (Bundle.main is the default)
                 Text("pencil", bundle: .main)
                 
                 Divider()
+                
+                Text("Other initializers").font(.title2)
                 
                 // Variables are not localized by default
                 let someString = "pen"
@@ -34,18 +53,16 @@ struct TextLocalizationPage: View {
                 // Do not localize a string literal
                 Text(verbatim: "pencil")
                 
-                Divider()
-                
                 // LocalizedStringResource initializer
                 let resource = LocalizedStringResource("pencil")
                 Text(resource)
                 
                 Divider()
                 
-                // Markdown-formatted strings can also be localized
-                Text("_Please visit our [website](https://www.example.com)._")
+                // TODO add AttributedString examples
             }
-        }
+        }.navigationTitle("Localization")
+            .environment(\.locale, $localize.wrappedValue ? .init(identifier: "it") : .current)
     }
 }
 

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/localization/TextLocalizationPage.swift
@@ -1,26 +1,49 @@
 import SwiftUI
 
 struct TextLocalizationPage: View {
-    var someString = "pen"
-    var object = LocalizedStringResource("pencil")
     
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                // Localized if possible
+                // Text's initializer accepts a LocalizedStringKey, which can be implicitly constructed from a string literal
+                // The value of the string is used for the development language localization
+                // Values for other languages are looked up in the default table using the string as key, if not found the value is used as is
                 Text("pencil")
                 
-                // Variables not localized by default
+                // The comment is shown in the localization table, useful for giving context to translators
+                Text("another pencil", comment: "Translator comment")
+                
+                // This comment will be ignored, since the same key was declared earlier. This is valid even if no comment was specified on the previous key.
+                Text("another pencil", comment: "A different comment")
+                
+                // Specify a different table for this localization
+                Text("pencil", tableName: "LocalizableAlternative")
+                
+                // Specify a bundle that contains the localizations table (Bundle.main is the default)
+                Text("pencil", bundle: .main)
+                
+                Divider()
+                
+                // Variables are not localized by default
+                let someString = "pen"
                 Text(someString)
                 
-                // Explicitly localize a variable
+                // Make variables localizable by wrapping them in LocalizableStringKey
                 Text(LocalizedStringKey(someString))
                 
-                // From localized string resource
-                Text(object)
-                
-                // Explicitly not localized
+                // Do not localize a string literal
                 Text(verbatim: "pencil")
+                
+                Divider()
+                
+                // LocalizedStringResource initializer
+                let resource = LocalizedStringResource("pencil")
+                Text(resource)
+                
+                Divider()
+                
+                // Markdown-formatted strings can also be localized
+                Text("_Please visit our [website](https://www.example.com)._")
             }
         }
     }
@@ -28,4 +51,8 @@ struct TextLocalizationPage: View {
 
 #Preview {
     TextLocalizationPage()
+}
+
+#Preview("Italian") {
+    TextLocalizationPage().environment(\.locale, .init(identifier: "it"))
 }


### PR DESCRIPTION
Added Text l10n examples following @suragch structure.

<img width="301" alt="Screenshot 2024-01-02 at 08 32 17" src="https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/54111322/108f134e-f568-411d-b1ff-6e7bf91d6d8d">
<img width="302" alt="Screenshot 2024-01-02 at 08 32 29" src="https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/54111322/b16e249a-4181-4f07-92e0-d5df053490f9">
<img width="300" alt="Screenshot 2024-01-02 at 08 32 41" src="https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/54111322/b462fb6a-6448-499a-a524-55c8b688adbc">
<img width="302" alt="Screenshot 2024-01-02 at 08 32 59" src="https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/54111322/1adee393-92f9-4e0d-b75b-e00cd926af50">