### PR TITLE
Add Text accessibility examples

### DIFF
--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/Localizable.xcstrings
@@ -23,6 +23,15 @@
         }
       }
     },
+    "/home/user/documents/photos/2024/vacation/destination/" : {
+
+    },
+    "125" : {
+
+    },
+    "Access Rotor by two-finger rotation. Select Headings in the Rotor.  Jump directly to the next or previous heading with swipe down and swipe up, respectively." : {
+
+    },
     "Accessibility" : {
 
     },
@@ -56,6 +65,15 @@
         }
       }
     },
+    "APPL" : {
+
+    },
+    "Apples (h2)" : {
+
+    },
+    "Automatic grammar agreement" : {
+
+    },
     "Blue" : {
 
     },
@@ -71,16 +89,40 @@
     "Collections" : {
 
     },
+    "Concorde (h3)" : {
+
+    },
+    "console text content type" : {
+
+    },
     "Controls" : {
+
+    },
+    "Default punctuation: All the world's a stage, And all the men and women merely players;" : {
 
     },
     "default scale" : {
 
     },
+    "Default Spell out characters" : {
+
+    },
+    "Do not spell out characters" : {
+
+    },
+    "Does not include punctuation: All the world's a stage, And all the men and women merely players;" : {
+
+    },
     "Emoji: 💙" : {
 
     },
+    "Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis." : {
+
+    },
     "Exceeds available space" : {
+
+    },
+    "file system text content type" : {
 
     },
     "First" : {
@@ -140,10 +182,40 @@
     "Frame" : {
 
     },
+    "Fruits (h1)" : {
+
+    },
+    "Golden Delicious (h3)" : {
+
+    },
     "Green" : {
 
     },
+    "Green Anjou (h3)" : {
+
+    },
     "Grid" : {
+
+    },
+    "Heading h1" : {
+
+    },
+    "Heading h2" : {
+
+    },
+    "Heading h3" : {
+
+    },
+    "Heading h4" : {
+
+    },
+    "Heading h5" : {
+
+    },
+    "Heading h6" : {
+
+    },
+    "Heading unspecified" : {
 
     },
     "Headline" : {
@@ -152,19 +224,25 @@
     "Hello" : {
 
     },
-    "Hello world" : {
-
-    },
     "Hello, 12345!" : {
 
     },
     "Hello, world!" : {
 
     },
+    "Honeycrisp (h3)" : {
+
+    },
     "HStack" : {
 
     },
+    "If the text has an accessibility label, only the accessibility label is spoken by VoiceOver, the text itself is skipped." : {
+
+    },
     "Image" : {
+
+    },
+    "Includes punctuation: All the world's a stage, And all the men and women merely players;" : {
 
     },
     "large" : {
@@ -206,7 +284,13 @@
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam efficitur, enim sit amet sodales rhoncus, nisl nisl varius urna, ut pulvinar odio nibh ac lorem. Etiam sit amet viverra erat, venenatis egestas tellus. Curabitur nec sodales lorem, nec tincidunt velit. Duis sed dolor pretium, viverra magna et, vehicula turpis. Cras suscipit venenatis felis, a dignissim nulla consequat sed. Sed non lacus nec velit vestibulum consequat. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam dignissim, ligula id condimentum feugiat, odio mi dapibus risus, quis pulvinar risus elit non ex.\nDonec vitae nisl ornare, efficitur mi vitae, maximus mauris. Curabitur imperdiet commodo tellus, vel pellentesque purus bibendum a. Nunc molestie ut nulla eu accumsan. Proin placerat metus sagittis, elementum augue vel, posuere dui. Aenean viverra enim in leo gravida, vel mollis leo vehicula. Duis aliquet convallis volutpat. Vivamus a nulla velit. Fusce vestibulum libero in cursus feugiat." : {
 
     },
-    "Magic" : {
+    "Lowered pitch" : {
+
+    },
+    "McIntosh (h3)" : {
+
+    },
+    "messaging text content type" : {
 
     },
     "Middle Aligned" : {
@@ -215,7 +299,16 @@
     "Motion" : {
 
     },
+    "narrative text content type" : {
+
+    },
+    "Normal pitch" : {
+
+    },
     "Other initializers" : {
+
+    },
+    "Pears (h2)" : {
 
     },
     "pen" : {
@@ -239,10 +332,19 @@
         }
       }
     },
+    "plain text content type" : {
+
+    },
     "Primitives" : {
 
     },
+    "Raised pitch" : {
+
+    },
     "Red" : {
+
+    },
+    "Red Bartlett (h3)" : {
 
     },
     "salad" : {
@@ -262,6 +364,24 @@
 
     },
     "secondary scale" : {
+
+    },
+    "Slightly lowered pitch" : {
+
+    },
+    "Slightly raised pitch" : {
+
+    },
+    "source code content type" : {
+
+    },
+    "Speech announcement is not queued" : {
+
+    },
+    "Speech announcement is queued" : {
+
+    },
+    "Spell out characters" : {
 
     },
     "Subheadline" : {
@@ -303,6 +423,9 @@
     "Text initialization from string + localization table specification" : {
 
     },
+    "Text with accessibility label" : {
+
+    },
     "Third" : {
 
     },
@@ -321,6 +444,9 @@
     "To be, or not to be, that is the question:" : {
 
     },
+    "To test the app with VoiceOver, open Settings, Accessibility, VoiceOver." : {
+
+    },
     "Top Aligned" : {
 
     },
@@ -333,7 +459,19 @@
     "UX divisions" : {
 
     },
+    "void main(List<String> arguments) { print('Default punctuation'); }" : {
+
+    },
+    "void main(List<String> arguments) { print('Do not include punctuation'); }" : {
+
+    },
+    "void main(List<String> arguments) { print('Include punctuation'); }" : {
+
+    },
     "VStack" : {
+
+    },
+    "word processing text content type" : {
 
     },
     "ZStack" : {

--- a/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/accessibility/TextAccessibilityPage.swift
+++ b/doc_swift_ui_gallery/swift_ui_gallery/swift_ui_gallery/primitives/text/accessibility/TextAccessibilityPage.swift
@@ -4,8 +4,108 @@ struct TextAccessibilityPage: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                Text("Hello world")
-            }
+                Divider()
+                Text("To test the app with VoiceOver, open Settings, Accessibility, VoiceOver.")
+
+                Divider()
+
+                Text("Text with accessibility label").accessibilityLabel("If the text has an accessibility label, only the accessibility label is spoken by VoiceOver, the text itself is skipped.")
+
+                Divider()
+
+                Text("Lowered pitch").speechAdjustedPitch(-1.0)
+                Text("Slightly lowered pitch").speechAdjustedPitch(-0.3)
+                Text("Normal pitch").speechAdjustedPitch(0)
+                Text("Slightly raised pitch").speechAdjustedPitch(0.3)
+                Text("Raised pitch").speechAdjustedPitch(1.0)
+
+                Divider()
+
+                // By default, VoiceOver voices punctuation based on surrounding context.
+                Text("Default punctuation: All the world's a stage, And all the men and women merely players;")
+                Text("Includes punctuation: All the world's a stage, And all the men and women merely players;").speechAlwaysIncludesPunctuation(true)
+                Text("Does not include punctuation: All the world's a stage, And all the men and women merely players;").speechAlwaysIncludesPunctuation(false)
+
+                Text("void main(List<String> arguments) { print('Default punctuation'); }")
+                Text("void main(List<String> arguments) { print('Include punctuation'); }").speechAlwaysIncludesPunctuation(true)
+                Text("void main(List<String> arguments) { print('Do not include punctuation'); }").speechAlwaysIncludesPunctuation(false)
+
+                Divider()
+
+                Text("Default Spell out characters")
+                Text("APPL")
+                Text("125")
+                Text("Spell out characters")
+                Text("APPL").speechSpellsOutCharacters(true)
+                Text("125").speechSpellsOutCharacters(true)
+                Text("Do not spell out characters")
+                Text("APPL").speechSpellsOutCharacters(false)
+                Text("125").speechSpellsOutCharacters(false)
+
+                Divider()
+
+                Text("Heading h1").accessibilityHeading(.h1).accessibilityAddTraits([.isHeader])
+                Text("Heading h2").accessibilityHeading(.h2).accessibilityAddTraits([.isHeader])
+                Text("Heading h3").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Heading h4").accessibilityHeading(.h4).accessibilityAddTraits([.isHeader])
+                Text("Heading h5").accessibilityHeading(.h5).accessibilityAddTraits([.isHeader])
+                Text("Heading h6").accessibilityHeading(.h6).accessibilityAddTraits([.isHeader])
+                Text("Heading unspecified").accessibilityHeading(.unspecified)
+
+                Divider()
+
+                // TODO: I couldn't figure out how to jump to the next heading of the same level...
+                // e.g. I want to jump from Apples to Pears with one gesture.
+                Text("Access Rotor by two-finger rotation. Select Headings in the Rotor.  Jump directly to the next or previous heading with swipe down and swipe up, respectively.")
+
+                Text("Fruits (h1)").accessibilityHeading(.h1).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Apples (h2)").accessibilityHeading(.h2).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Golden Delicious (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Honeycrisp (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("McIntosh (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Pears (h2)").accessibilityHeading(.h2).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Concorde (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Green Anjou (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+                Text("Red Bartlett (h3)").accessibilityHeading(.h3).accessibilityAddTraits([.isHeader])
+                Text("Etiam viverra eleifend elit ullamcorper aliquet. Nam sollicitudin lectus nisl, finibus volutpat augue posuere quis.")
+
+                Divider()
+
+                // This doesn't seem to be doing anything, but it might be a Swift UI bug?
+                // https://swiftui-lab.com/bug-watch/
+                // > speechAnnouncementsQueued() does nothing - FB9313957
+                // Asked for help on StackOverflow:
+                // https://stackoverflow.com/q/77773505
+                Text("Speech announcement is queued").speechAnnouncementsQueued(true)
+                Text("Speech announcement is not queued").speechAnnouncementsQueued(false)
+
+                Divider()
+
+                // TODO: I didn't hear anything changed with the different text content types.
+                // Found nothing on Google, asked on Twitter...
+                // https://twitter.com/vincevargadev/status/1743302073259532324
+                // Then asked for help on StackOverflow:
+                // https://stackoverflow.com/q/77773708
+                Text("console text content type").accessibilityTextContentType(.console)
+                Text("file system text content type").accessibilityTextContentType(.fileSystem)
+                Text("/home/user/documents/photos/2024/vacation/destination/").accessibilityTextContentType(.fileSystem)
+                Text("/home/user/documents/photos/2024/vacation/destination/").accessibilityTextContentType(.messaging)
+                Text("messaging text content type").accessibilityTextContentType(.messaging)
+                Text("narrative text content type").accessibilityTextContentType(.narrative)
+                Text("plain text content type").accessibilityTextContentType(.plain)
+                Text("source code content type").accessibilityTextContentType(.sourceCode)
+                Text("word processing text content type").accessibilityTextContentType(.wordProcessing)
+
+                Divider()
+            }.padding(.horizontal, 12)
         }.navigationTitle("Accessibility")
     }
 }


### PR DESCRIPTION
I added `Text` accessibility examples to the SwiftUI Gallery app #7.

VoiceOver guides:
* https://support.apple.com/guide/iphone/turn-on-and-practice-voiceover-iph3e2e415f/ios
* https://support.apple.com/guide/iphone/use-voiceover-gestures-iph3e2e2281/17.0/ios/17.0

<img src="https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/9061239/404cafa8-f12a-4b53-804d-631bdefe1001" height="700px" alt="Accessibility Screen">

I attached a video as a screenshot doesn't really capture what is important in this PR. Don't forget to turn on the sound on the video.


https://github.com/Flutter-Bounty-Hunters/swift_ui/assets/9061239/71663209-1c96-4f62-b763-d3beede63ca9



